### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-ransac-def.R
+++ b/feedback/topdown-ransac-def.R
@@ -1,0 +1,115 @@
+#' Fit a random sample consensus (RANSAC) linear model for outlier-contaminated data
+#     Details: https://en.wikipedia.org/wiki/Random_sample_consensus
+#' input: formula: valid lm formula (univariate response only, no offsets)
+#'        data: data.frame containing the variables in formula
+#'        error_threshold: observations with absolute prediction error below
+#           this are considered for the consensus set
+#'        inlier_threshold: minimum size of consensus set
+#'        iterations: how many random draws of candidate sets to try (
+#'          defaults to half the number of observations in data)
+#'        seed: RNG seed
+#' output: list with model (best fit lm-object on consensus set),
+#'   data (modified input data (complete cases), with additional boolean variable
+#'   ".consensus_set" indicating the best set that was found)
+#' imports checkmate, future.lapply. use future::plan("multiprocess") for parallelizing.
+ransaclm <- function(formula, data, error_threshold, inlier_threshold,
+                     iterations = nrow(data) / 2, seed = NULL) {
+  checkmate::assert_class(formula, "formula")
+  checkmate::assert_class(data, "data.frame")
+  checkmate::assert_number(error_threshold, lower = 0)
+  checkmate::assert_integerish(inlier_threshold, lower = 1, upper = nrow(data) - 1)
+  checkmate::assert_count(iterations, positive = TRUE)
+  checkmate::assert_int(seed, null.ok = TRUE, lower = 1)
+
+  if (!is.null(seed)) set.seed(as.integer(seed))
+
+  model_all <- try(lm(formula, data), silent = TRUE)
+  if (inherits(model_all, "try-error")) {
+    stop("Could not fit model on the supplied data, `lm` exited with error:\n",
+         model_all)
+  }
+  # multivariate response not allowed, easiest way to check is to disallow
+  #   matrix-coefficients
+  if (is.matrix(coefficients(model_all))) {
+    stop("Multivariate response models are not implemented.")
+  }
+  if (!is.null(model_all[["offset"]])) {
+    stop("Models with offset are not implemented.")
+  }
+
+  # model.frame gets rid of incomplete observations in <data>
+  data_all <- model.frame(model_all)
+  design <- model.matrix(model_all)
+  response <- model.response(data_all)
+
+  # do the work:
+  candidates <- future.apply::future_replicate(
+    n = iterations,
+    expr = ransac_once(design, response, error_threshold, inlier_threshold),
+    simplify = FALSE
+  )
+  best_error <- which.min(vapply(candidates, `[[`, "error",
+                                 FUN.VALUE = numeric(1)))
+  if (!length(best_error)) {
+    warning("No RANSAC model satisfied criteria, try lower inlier or error tresholds.\n")
+    return(list(model = NULL, data = data_all))
+  }
+  best_set <- candidates[[best_error]][["set"]]
+
+  # use update.lm so return object is a real lm-object (not a list from .lm.fit)
+  best_model <- update(model_all, data = data_all[best_set, ])
+  data_all$.consensus_set <- seq_len(nrow(data_all)) %in% best_set
+  list(model = best_model, data = data_all)
+}
+
+ransac_once <- function(design, response, error_threshold, inlier_threshold) {
+  # 1. generate candidate sets
+  candidate_set <- get_candidate_set(design, response, error_threshold)
+  # 2. filter out too small candidate sets
+  keep_set <- length(candidate_set) > inlier_threshold
+  if (!keep_set) {
+    return(list(error = NA_real_, set = numeric(0)))
+  }
+  # 3. refit & return error on candidate set
+  error <- refit_candidate_set(candidate_set,
+                               design = design, response = response)
+  list(error = error, set = candidate_set)
+}
+
+# return indices of all observations which <design>%*%<coefficients> predicts well
+get_inliers <- function(coefficients, design, response, error_threshold) {
+  predictions <- design %*% coefficients
+  errors <- response - predictions
+  which(abs(errors) < error_threshold)
+}
+
+# candidate for the consensus set based on a random draw of a minimal dataset:
+get_candidate_set <- function(design, response, error_threshold) {
+  # draw row indices of candidate observations for minimal dataset
+  use <- sample(x = seq_len(nrow(design)), size = ncol(design), replace = FALSE)
+  # use .lm.fit instead of lm for better performance
+  candidate_model <- try(.lm.fit(x = design[use, ], y = response[use]))
+  if (inherits(candidate_model, "try-error") ||
+      any(is.na(candidate_model[["coefficients"]]))) {
+    warning("Model fit failed on subsample.")
+    return(numeric(0))
+  }
+  # get set of observations which this_model predicts well
+  get_inliers(candidate_model[["coefficients"]],
+              design = design, response = response,
+              error_threshold = error_threshold)
+}
+
+# get error for candidate consensus set
+refit_candidate_set <- function(candidate_set, design, response) {
+  # use .lm.fit instead of lm for better performance
+  candidate_set_model <- try(.lm.fit(
+    x = design[candidate_set, ],
+    y = response[candidate_set]
+  ))
+  if (inherits(candidate_set_model, "try-error")) {
+    warning("Model fit failed on candidate set.")
+    return(NA_real_)
+  }
+  mean(residuals(candidate_set_model)^2)
+}

--- a/feedback/topdown-ransac-sol.Rmd
+++ b/feedback/topdown-ransac-sol.Rmd
@@ -1,0 +1,188 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+
+```{r, child = "topdown-ransac-ex.Rmd"}
+```
+
+-------------
+
+## Lösung:
+
+
+Die folgenden Funktionen implementiert das gewünschte:
+
+```{r, code = readLines("topdown-ransac-def.R")}
+```
+
+S. ganz unten für eine rein sequentielle, nicht parallelisierte Implementation 
+die sich stärker an dem Pseudo-Code in Wikipedia orientiert.
+
+Parallelisierung bringt hier erst bei recht großen Datensätzen Zeitvorteile:
+
+```r
+data_big <- make_ransac_data(n_obs = 10000, n_coef = 10, inlier_fraction = 0.7)
+rbenchmark::benchmark(
+  seq = {
+    future::plan("sequential")
+    ransaclm(y ~ . - inlier, data = data_big, 
+             error_threshold = 2,  inlier_threshold = 5000)
+  },
+  par = {
+    future::plan("multicore", workers = 20)
+    ransaclm(y ~ . - inlier, data = data_big, 
+             error_threshold = 2,  inlier_threshold = 5000)
+  }
+)
+#  test replications elapsed relative user.self sys.self user.child sys.child
+#2  par          100  68.319    1.000    41.161   19.956    182.699    68.478
+#1  seq          100 143.945    2.107   143.834    0.105      0.000     0.000
+```
+
+Weitere Tests:
+```{r, ransac_test_advanced, error =TRUE,fig.width = 6, fig.height = 4}
+# immer set.seed() um Ergebnisse reproduzierbar zu machen...
+set.seed(12122)
+data_simple <- make_ransac_data(100, 1, inlier_fraction = 0.7)
+
+# inlier_threshold zu hoch --> checke warnung & erwartetes Rückgabeobjekt
+testthat::expect_warning(
+  fail_inlier <- ransaclm(y ~ . - inlier,
+                          data = data_simple, error_threshold = 2,
+                          inlier_threshold = 99, seed = 20161110
+  ))
+testthat::expect_null(fail_inlier$model)
+
+# response mit NAs
+data_simple_nay <- data_simple
+data_simple_nay$y[1:50] <- NA
+ransac_simple_nay <- ransaclm(y ~ . - inlier,
+  data = data_simple_nay, error_threshold = 2,
+  inlier_threshold = 25, seed = 20161110
+)
+validate_ransac(ransac_simple_nay)
+
+# kovariable mit NAs
+data_simple_nax <- data_simple
+data_simple_nax$x[51:100] <- NA
+ransac_simple_nax <- ransaclm(y ~ . - inlier,
+  data = data_simple_nax, error_threshold = 2,
+  inlier_threshold = 25, seed = 20161110
+)
+validate_ransac(ransac_simple_nax)
+
+# multivariat
+set.seed(121221)
+data_multi <- make_ransac_data(500, 3, inlier_fraction = 0.9)
+
+ransac_multi <- ransaclm(y ~ . - inlier,
+  data = data_multi, error_threshold = 1,
+  inlier_threshold = 420, seed = 20161111
+)
+validate_ransac(ransac_multi, plot = FALSE)
+
+# multivariat mit interaktion
+ransac_multi <- ransaclm(y ~ x.1 * x.2 * x.3 - inlier,
+  data = data_multi, error_threshold = 2,
+  inlier_threshold = 400, seed = 20161110
+)
+validate_ransac(ransac_multi, plot = FALSE)
+# --> Modell fehlspezifiziert, dementsprechend schlechte Schätzung
+#     aber outlier-Identifikation noch ok
+
+# factor variable (with true coefficients 0)
+data_factor <- cbind(data_simple, x_factor = gl(4, 25))
+ransac_factor <- ransaclm(y ~ . - inlier,
+  data = data_factor, error_threshold = 2,
+  inlier_threshold = 50, seed = 20161110
+)
+validate_ransac(ransac_factor, plot = FALSE)
+
+# no outliers
+set.seed(12122)
+data_inliers <- data.frame(y = 1:100 + rnorm(100), x = 1:100, inlier = TRUE)
+ransac_inliers <- ransaclm(y ~ . - inlier,
+  data = data_inliers, error_threshold = 3,
+  inlier_threshold = 95, seed = 20161111
+)
+validate_ransac(ransac_inliers, plot = TRUE)
+```
+
+Hinweis: Durch die Formelnotation mit "`- inlier`" bleibt -- in meiner Implementation, zumindest -- die ursprünglich angelegte `inlier`-Variable, welche die wahren *inlier* identifiziert, im Datensatz des Rückgabeobjekts erhalten so dass wir mit `validate_ransac` eine Kreuztabelle der wahren und entdeckten Inlier/Outlier erzeugen können. Wenn `inlier` nicht in der Formel vorkäme würde diese Spalte nicht von `model.frame(model_all)` zurückgeliefert werden.
+
+Alternative, sequentielle Implementation:
+```{r, ransac-def-seq, eval = FALSE}
+#' Fit a random sample consensus (RANSAC) linear model for outlier-contaminated data
+#     Details: https://en.wikipedia.org/wiki/Random_sample_consensus
+#' input: formula: valid lm formula (univariate response only, no offsets)
+#'        data: data.frame containing the variables in formula
+#'        error_threshold: observations with prediction error below this are part of the
+#'          consensus set
+#'        inlier_threshold: minimum size of consensus set
+#'        iterations: how many random draws of candidate sets to try (
+#'          defaults to half the number of observations in data)
+#'        seed: RNG seed
+#' output: list with model (best fit lm-object on consensus set),
+#'   data (modified input data (complete cases), with additional boolean variable
+#'   ".consensus_set" indicating the best set that was found)
+ransaclm <- function(formula, data, error_threshold, inlier_threshold,
+                     iterations = nrow(data) / 2, seed = NULL) {
+  checkmate::assert_class(formula, "formula")
+  checkmate::assert_class(data, "data.frame")
+  checkmate::assert_number(error_threshold, lower = 0)
+  checkmate::assert_integerish(inlier_threshold, lower = 1, upper = nrow(data) - 1)
+  checkmate::assert_count(iterations, positive = TRUE)
+  checkmate::assert_int(seed, null.ok = TRUE, lower = 1)
+
+  if (!is.null(seed)) set.seed(as.integer(seed))
+
+  model_all <- try(lm(formula, data), silent = TRUE)
+  if (inherits(model_all, "try-error")) {
+    stop(
+      "Could not fit specified model on the supplied data, lm exited with error:\n",
+      model_all
+    )
+  }
+  # multivariate response models not allowed, easiest way to check is to disallow
+  #   matrix-coefficients
+  if (is.matrix(coefficients(model_all))) {
+    stop("Multivariate response models are not implemented.")
+  }
+  if (!is.null(model_all$offset)) {
+    stop("Models with offset are not implemented.")
+  }
+
+  # model.frame etc gets rid of incomplete observations in <data>
+  data_all <- model.frame(model_all)
+  design <- model.matrix(model_all)
+  response <- model.response(data_all)
+
+  # initialize with infinite error so we always start iterating
+  best_error <- Inf
+  best_set <- best_model <- NULL
+
+  for (i in seq_len(iterations)) {
+    candidate_set <- get_candidate_set(design, response, error_threshold)
+    if (length(candidate_set) < inlier_threshold) {
+      next
+    }  
+    candidate_error <- refit_consensus_set(candidate_set,
+      design = design,
+      response = response
+    )
+    if (candidate_error < best_error) {
+      best_error <- candidate_error
+      best_set <- candidate_set
+    }
+  }
+  if (is.null(best_set)) {
+    warning("No RANSAC model satisfied criteria, decrease inlier or error tresholds.\n")
+    return(list(model = NULL, data = data_all))
+  }
+  # add consensus_set variable to cleaned input data, then return model & modified data
+  best_model <- update(model_all, data = data_all[best_set, ])
+  data_all$.consensus_set <- 1:nrow(data_all) %in% best_set
+  list(model = best_model, data = data_all)
+}
+```


### PR DESCRIPTION
@jaeeun-n 

solider versuch, aber das was sie da implementiert haben ist mMn nicht der Algo der in Wikipedia beschrieben wird, weicht in mehreren entscheidenden details ab... 
was den programmierstil angeht bin ich aber recht zufrieden, das haben sie schon gut gemacht.

--------------------------------------------------------------

- sehr gute input checks.  

- sie haben den algo falsch implementiert: sie bestimmen "best_candidate_set" danach wie klein der fehler des "minimum_observations"-modells ist. das ist aber nicht RANSAC -- sie müssen das "minimum_observations"-modell ersetzen durch ein modell was sie auf dem aus diesem modell bestimmten `inlier_set` nochmal gefittet haben (falls das inlier_set groß genug ist...) -- in dem Wikipedia-Pseudocode:
```
  if the number of elements in alsoInliers is > d then
        // This implies that we may have found a good model
        // now test how good it is.
        betterModel := model parameters fitted to all points in maybeInliers and alsoInliers
        thisErr := a measure of how well betterModel fits these points
``` 
dieser schritt "better model"  fehlt in ihrem code komplett.
man sieht in den bsp auch dass ihre koeffizientenschätzer systematisch eher schlecht sind....

- struktur ihres programms ist sehr speicheruneffizient:   
die liste "subsample_models" enthält *alle* ausprobierten fits (also 100e oder 1000e von `lm`_objekten, jedes mit einer  kompletten kopie von den daten, residuen, etc pp, das skaliert für große probleme oder viele iterationen nicht). 1. nichts davon wird später wirklich benötigt außer der index vektor für das candidate set (und der fehler auf dem candidate set, dazu s. nächster punkt....), also wozu abspeichern und 2. wenn `consensus_set_sizes < inlier_threshold` dann brauche ich dieses modell usw gar nicht abspeichern weil es ja eh nicht in frage kommt. 


- https://github.com/fort-w2021/ransac-ex-jaeeun-n/blob/6e82e7ceb3b44ada745e0551e00d9395d89ea0f9/ransac-sol.R#L18
`minimum_observations = inlier_threshold` entspricht nicht spezifikation, das muss `minimum_observations = number_of_fitted_coefs`  sein....

- https://github.com/fort-w2021/ransac-ex-jaeeun-n/blob/6e82e7ceb3b44ada745e0551e00d9395d89ea0f9/ransac-sol.R#L20 besser mit `library` -- `require` erzeugt keinen fehler wenn das paket nicht geladen werden kann, das wollen wir ja aber hier.

- BUG:
https://github.com/fort-w2021/ransac-ex-jaeeun-n/blob/6e82e7ceb3b44ada745e0551e00d9395d89ea0f9/ransac-sol.R#L140-L141 
find_best_consensus_set retourniert consensus_set <- NULL falls kein set größer als  inlier_threshold ist, das wird aber nicht abgefangen und dann versucht best_model mit leeren Daten zu fitten und schmeißt nen fehler... :(
```
> fail_inlier <- ransaclm(y ~ . - inlier,
+                         data = data_simple, error_threshold = 2,
+                         inlier_threshold = 99, seed = 20161110
+ )
Error in lm.fit(x, y, offset = offset, singular.ok = singular.ok, ...) : 
  0 (non-NA) cases
> traceback()
3: do.call(lm, lm_arguments) at ransac-sol.R#197
2: fit_lm(formula = formula, data = data[best_consensus_set, ], 
       lm_arguments = lm_arguments) at ransac-sol.R#74
1: ransaclm(y ~ . - inlier, data = data_simple, error_threshold = 2, 
       inlier_threshold = 99, seed = 20161110)
``` 

- https://github.com/fort-w2021/ransac-ex-jaeeun-n/blob/6e82e7ceb3b44ada745e0551e00d9395d89ea0f9/ransac-sol.R#L154 BUG --- berechnet fehler auf dem kompletten datensatz, sollte aber laut spezifikation nur den fehler auf den subsampled_rows und is_inlier berechnen :( 

- https://github.com/fort-w2021/ransac-ex-jaeeun-n/blob/6e82e7ceb3b44ada745e0551e00d9395d89ea0f9/ransac-sol.R#L197 das kann schiefgehen und braucht ein `try` + nachverarbeitung

